### PR TITLE
more tests; some fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rogpeppe/godef
 
 require (
 	9fans.net/go v0.0.0-20150709035532-65b8cf069318
-	golang.org/x/tools v0.0.0-20181008205924-a2b3f7f249e9
+	golang.org/x/tools v0.0.0-20181106213628-e21233ffa6c3
 )
 
-replace golang.org/x/tools => github.com/ianthehat/tools v0.0.0-20181025151029-18a214bc1bc9
+replace golang.org/x/tools => /home/rog/gohack/golang.org/x/tools

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,9 @@ github.com/ianthehat/tools v0.0.0-20181023233804-d182e3d451dd h1:jLXMB+HG6939n3W
 github.com/ianthehat/tools v0.0.0-20181023233804-d182e3d451dd/go.mod h1:Xi7aiaH3WwgqRUDZtJRysdVdLNWSyQgY5/gmQO9UPtQ=
 github.com/ianthehat/tools v0.0.0-20181025151029-18a214bc1bc9 h1:T6wJXrB2zT+lvriQVlqc6hL4DPKg56enPcaVW+z7qWM=
 github.com/ianthehat/tools v0.0.0-20181025151029-18a214bc1bc9/go.mod h1:Xi7aiaH3WwgqRUDZtJRysdVdLNWSyQgY5/gmQO9UPtQ=
+golang.org/x/tools v0.0.0-20181008205924-a2b3f7f249e9 h1:T3nuFyXXDj5KXX9CqQm/r/YEL4Gua01s/ZEdfdLyJ2c=
+golang.org/x/tools v0.0.0-20181008205924-a2b3f7f249e9/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181106213628-e21233ffa6c3 h1:mWDqf+8WK8+4aHsqe+AyUfxE1nkL+QGCVk1Rxivr0aM=
+golang.org/x/tools v0.0.0-20181106213628-e21233ffa6c3/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181111003725-6d71ab8aade0 h1:/3bE5RJC79/P5HYl3owP5NbsS+fnVQvUj9tsEE5x/qM=
+golang.org/x/tools v0.0.0-20181111003725-6d71ab8aade0/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/godef_test.go
+++ b/godef_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"go/token"
 	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/tools/go/packages/packagestest"
@@ -17,22 +20,43 @@ func testGoDef(t *testing.T, exporter packagestest.Exporter) {
 	exported := packagestest.Export(t, packagestest.GOPATH, modules)
 	defer exported.Cleanup()
 	count := 0
+	posStr := func(p token.Position) string {
+		return localPos(p, exported, modules)
+	}
 	if err := exported.Expect(map[string]interface{}{
 		"godef": func(src, target token.Position) {
 			count++
 			input, err := ioutil.ReadFile(src.Filename)
 			if err != nil {
-				t.Errorf("Failed %v: %v", src, err)
+				t.Fatalf("cannot read source: %v", err)
 				return
+			}
+			// There's a "saved" version of the file, so
+			// copy it to the original version; we want the
+			// Expect method to see the in-editor-buffer
+			// versions of the files, but we want the godef
+			// function to see the files as they should
+			// be on disk, so that we're actually testing the
+			// define-in-buffer functionality.
+			savedFile := src.Filename + ".saved"
+			if _, err := os.Stat(savedFile); err == nil {
+				savedData, err := ioutil.ReadFile(savedFile)
+				if err != nil {
+					t.Fatalf("cannot read saved file: %v", err)
+				}
+				if err := ioutil.WriteFile(src.Filename, savedData, 0666); err != nil {
+					t.Fatalf("cannot write saved file: %v", err)
+				}
+				defer ioutil.WriteFile(src.Filename, input, 0666)
 			}
 			fSet, obj, err := godef(exported.Config, src.Filename, input, src.Offset)
 			if err != nil {
-				t.Errorf("Failed %v: %v", src, err)
+				t.Errorf("godef error %v: %v", posStr(src), err)
 				return
 			}
 			pos := objToPos(fSet, obj)
 			if pos.String() != target.String() {
-				t.Errorf("Got %v expected %v", pos, target)
+				t.Errorf("unexpected result %v -> %v want %v", posStr(src), posStr(pos), posStr(target))
 			}
 		},
 	}); err != nil {
@@ -41,4 +65,21 @@ func testGoDef(t *testing.T, exporter packagestest.Exporter) {
 	if count == 0 {
 		t.Fatalf("No godef tests were run")
 	}
+}
+
+var cwd, _ = os.Getwd()
+
+func localPos(pos token.Position, e *packagestest.Exported, modules []packagestest.Module) string {
+	f := pos.Filename
+	for _, m := range modules {
+		md := filepath.FromSlash(m.Name)
+		i := strings.LastIndex(f, md)
+		if i == -1 {
+			continue
+		}
+		f = f[i+len(md)+1:]
+		pos.Filename = filepath.Join(cwd, "testdata", f)
+		break
+	}
+	return pos.String()
 }

--- a/testdata/b/b.go
+++ b/testdata/b/b.go
@@ -2,6 +2,21 @@ package b
 
 import "github.com/rogpeppe/godef/a"
 
+type S1 struct { //@S1
+	F1 int //@mark(S1F1, "F1")
+	S2     //@godef("S2", S2), mark(S1S2, "S2")
+}
+
+type S2 struct { //@S2
+	F1 string //@mark(S2F1, "F1")
+	F2 int    //@mark(S2F2, "F2")
+}
+
 func Bar() {
 	a.Stuff() //@godef("Stuff", Stuff)
+	var x S1  //@godef("S1", S1)
+	x.S2      //@godef("S2", S1S2)
+	x.F1      //@godef("F1", S1F1)
+	x.F2      //@godef("F2", S2F2)
+	x.S2.F1   //@godef("F1", S2F1)
 }

--- a/testdata/b/c.go
+++ b/testdata/b/c.go
@@ -1,0 +1,8 @@
+package b
+
+// This is the in-editor version of the file.
+// The on-disk version is in c.go.saved.
+
+var _ = S1{ //@godef("S1", S1)
+	F1: 99, //@godef("F1", S1F1)
+}

--- a/testdata/b/c.go.saved
+++ b/testdata/b/c.go.saved
@@ -1,0 +1,7 @@
+package b
+
+// This is the on-disk version of c.go, which represents
+// the in-editor version of the file.
+
+}
+


### PR DESCRIPTION
We add some more tests, including two failing tests, one
of which is fixed (it now doesn't ignore the in-editor version
of the buffer).

Also fix the go tools dependency so it refers to a working
version of the tools module that's not after the breaking
change made to the `contains:` pattern.

We also change the test output so that it prints the path
to the file in the testdata directory rather than in the packagestest
temporary directory.

The issue that still needs to be fixed is that if you
jump to the definition of an embedded field from that
field itself, it should go to the type referred to rather
than going to the same place.

Still needed: a test that godef on an import path will
print the directory containing the imported package.
I'm not sure whether to stay within the packagestest
Expect framework for that one.

